### PR TITLE
Remove IGNORE from showing in Tables

### DIFF
--- a/controller/irb.py
+++ b/controller/irb.py
@@ -62,7 +62,7 @@ class Irb:
                 df['Date Submitted Year'] = pd.DatetimeIndex(df['Date Submitted']).year
                 df['Date Submitted Month'] = df['Date Submitted Month'].fillna(0)
                 df['Date Submitted Year'] = df['Date Submitted Year'].fillna(20200)
-                remove_index = df[df['Date Submitted Year'] < 2020].index
+                remove_index = df[(df['Reporting Category'] == 'IGNORE') | (df['Date Submitted Year'] < 2020)].index
                 if len(remove_index):
                     df.drop(df.index[remove_index], inplace=True)
                 df['Date Submitted Year'] = df['Date Submitted Year'].replace(20200, 0)

--- a/controller/ufirst.py
+++ b/controller/ufirst.py
@@ -15,6 +15,9 @@ class Ufirst:
             total_proposals = 0
             if data is not None:
                 df = pd.read_excel(data)
+                remove_index = df[df['Reporting Category'] == 'IGNORE'].index
+                if len(remove_index):
+                    df.drop(df.index[remove_index], inplace=True)
                 total_proposals = len(df["CLK_PROPOSAL_ID"].index)
             return total_proposals
         except:
@@ -45,6 +48,9 @@ class Ufirst:
                 df['CLK_CURRENTSTATE'] = df['CLK_CURRENTSTATE'].map(status_mapping)
                 df['CLK_CURRENTSTATE'] = df['CLK_CURRENTSTATE'].fillna("6-Unmapped")
                 df = df.fillna("")
+                remove_index = df[df['Reporting Category']=='IGNORE'].index
+                if len(remove_index):
+                    df.drop(df.index[remove_index], inplace=True)
                 total_proposals = len(df["CLK_PROPOSAL_ID"].index)
                 total_direct = df['CLK_TOTAL_DIRECT_COSTS'].sum()
                 total_indirect = df['CLK_TOTAL_INDIRECT_COSTS'].sum()


### PR DESCRIPTION
Adding logic to remove unimportant data from the Proposals and Awards table and the IRB Submissions table. If the Reporting Category is equal to "IGNORE" the data will not be shown in the tables.