### PR TITLE
Updating Excel Parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## [1.0.1] - 2021-03-02
+### Summary
+- Added new route to check the health of the application

--- a/controller/enrollment.py
+++ b/controller/enrollment.py
@@ -83,7 +83,7 @@ class Enrollment:
                     result.append(res)
                 data = read_file(self.irb_url)
                 if data is not None:
-                    df1 = pd.read_excel(data)
+                    df1 = pd.read_excel(data, engine='openpyxl')
                     if df1 is not None:
                         df1['Reporting Category'] = df1['Reporting Category'].fillna("")
                         df1 = df1[['ID', 'Reporting Category']]

--- a/controller/irb.py
+++ b/controller/irb.py
@@ -14,7 +14,7 @@ class Irb:
             data = read_file(self.url)
             total_irb = 0
             if data is not None:
-                df = pd.read_excel(data)
+                df = pd.read_excel(data, engine='openpyxl')
                 df['Date Submitted Month'] = pd.DatetimeIndex(df['Date Submitted']).month
                 df['Date Submitted Year'] = pd.DatetimeIndex(df['Date Submitted']).year
                 df['Date Submitted Month'] = df['Date Submitted Month'].fillna(0)
@@ -32,7 +32,7 @@ class Irb:
         try:
             data = read_file(self.url)
             if data is not None:
-                df = pd.read_excel(data)
+                df = pd.read_excel(data, engine='openpyxl')
                 df['Reporting Category'] = df['Reporting Category'].fillna("Unassigned")
                 df['Review Type'] = df['Review Type'].fillna("Unassigned")
                 df = df.fillna("")

--- a/controller/ufirst.py
+++ b/controller/ufirst.py
@@ -14,7 +14,7 @@ class Ufirst:
             data = read_file(self.url)
             total_proposals = 0
             if data is not None:
-                df = pd.read_excel(data)
+                df = pd.read_excel(data, engine='openpyxl')
                 remove_index = df[df['Reporting Category'] == 'IGNORE'].index
                 if len(remove_index):
                     df.drop(df.index[remove_index], inplace=True)
@@ -28,7 +28,7 @@ class Ufirst:
         try:
             data = read_file(self.url)
             if data is not None:
-                df = pd.read_excel(data)
+                df = pd.read_excel(data, engine='openpyxl')
                 df['CLK_TOTAL_DIRECT_COSTS'] = df['CLK_TOTAL_DIRECT_COSTS'].fillna(0)
                 df['CLK_TOTAL_INDIRECT_COSTS'] = df['CLK_TOTAL_INDIRECT_COSTS'].fillna(0)
                 df['CLK_GRAND_TOTAL'] = df['CLK_GRAND_TOTAL'].fillna(0)

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import sys
 
 import requests
 from flask import render_template
-
+from flask import Response
 from config import config
 from controller.enrollment import Enrollment
 from controller.irb import Irb
@@ -102,3 +102,6 @@ def get_enrollment_data():
         print(sys.exc_info())
         return render_template('base.html',
                                message="Something went wrong!! Please report this incident to ocr-apps@ahc.ufl.edu.")
+
+def health():
+    return Response("Healthy", status=200, mimetype='application/json')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask==1.1
 pandas
-xlrd >= 1.0.0
+openpyxl
 numpy
 lxml==4.6.2
 pickle-mixin

--- a/routes.py
+++ b/routes.py
@@ -1,4 +1,4 @@
-from main import get_ufirst_data, get_irb_data, get_enrollment_data, get_home
+from main import get_ufirst_data, get_irb_data, get_enrollment_data, get_home, health
 
 def init_api_routes(app):
     if app:
@@ -6,3 +6,4 @@ def init_api_routes(app):
         app.add_url_rule('/ufirst', 'get_ufirst_data', get_ufirst_data, methods=['GET'])
         app.add_url_rule('/irb', 'get_irb_data', get_irb_data, methods=['GET'])
         app.add_url_rule('/enrollment', 'get_enrollment_data', get_enrollment_data, methods=['GET'])
+        app.add_url_rule('/health', 'health', health, methods=['GET'])


### PR DESCRIPTION
XLRD updated in December 2020. The update to XLRD dropped support for all Excel files except XLS files. Due to this update the parser needed to be updated away from XLRD. The new Excel parser is openpyxl. Pandas at this time defaults to XLRD so it is necessary to specify the engine. 

More on this issue can be read at: https://stackoverflow.com/questions/65254535/xlrd-biffh-xlrderror-excel-xlsx-file-not-supported